### PR TITLE
remove problematic in-process kernel behavior

### DIFF
--- a/IPython/kernel/inprocess/ipkernel.py
+++ b/IPython/kernel/inprocess/ipkernel.py
@@ -52,10 +52,7 @@ class InProcessKernel(IPythonKernel):
     stdin_socket = Instance(DummySocket, ())
 
     def __init__(self, **traits):
-        # When an InteractiveShell is instantiated by our base class, it binds
-        # the current values of sys.stdout and sys.stderr.
-        with self._redirected_io():
-            super(InProcessKernel, self).__init__(**traits)
+        super(InProcessKernel, self).__init__(**traits)
 
         self.iopub_socket.on_trait_change(self._io_dispatch, 'message_sent')
         self.shell.kernel = self


### PR DESCRIPTION
It was accessing traits with default values prior to `super().__init__` loading the actual values from kwargs. Since `_session_default` never gets registered, the default value generation fails.

This is apparently no longer necessary, if it ever was.
